### PR TITLE
ci: fix deprecated use of set-output

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,8 @@ jobs:
           ):
               publishing = "true"
               print("Publishing chart")
-          print(f"::set-output name=publishing::{publishing}")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"publishing={publishing}\n")
 
       - name: Set up QEMU (for docker buildx)
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Remnant of copy pasting from z2jh, that also needs this fix - see https://github.com/jupyterhub/team-compass/issues/579 for info.