### PR TITLE
ci: use ssh deploy key for release.yaml to push to this repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,8 +32,6 @@ jobs:
   #
   release:
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@v3
@@ -90,6 +88,26 @@ jobs:
         run: |
           git config --global user.email "github-actions@example.local"
           git config --global user.name "GitHub Actions user"
+
+      - name: Setup push rights to Helm chart repository's git repo
+        # This was setup by...
+        #
+        # 1. Generating a private/public key pair:
+        #    ssh-keygen -t ed25519 -C "2i2c-org/binderhub-service" -f /tmp/id_ed25519
+        #
+        # 2. Registering the private key (/tmp/id_ed25519) as a secret for this
+        #    repo: https://github.com/2i2c-org/binderhub-service/settings/secrets/actions
+        #
+        # 3. Registering the public key (/tmp/id_ed25519.pub) as a deploy key
+        #    with push rights for the Helm chart repository's git repo:
+        #    https://github.com/2i2c-org/binderhub-service/settings/keys
+        #
+        if: steps.publishing.outputs.publishing
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          echo "${{ secrets.HELM_CHART_REPO_DEPLOY_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
 
       - name: Setup docker push rights to quay.io
         if: steps.publishing.outputs.publishing


### PR DESCRIPTION
I think this can finally resolve both #2 and #3, but we'll see. It should be possible to configure chartpress to use GITHUB_TOKEN etc as well, but its a bit tricky and I don't want to enter that rabbit hole for now. With this setup, we can also easily transition to an external github repo as a helm chart repository later.