### PR TITLE
Make chart installable and complete values.schema.yaml

### DIFF
--- a/binderhub-service/Chart.yaml
+++ b/binderhub-service/Chart.yaml
@@ -2,6 +2,9 @@
 apiVersion: v2
 name: binderhub-service
 version: 0.0.1-set.by.chartpress
+# FIXME: appVersion should represent the version of binderhub in
+#        images/binderhub-service/requirements.txt
+#
 appVersion: "1.0.0"
 description: A BinderHub installation separate from JupyterHub
 keywords: [binderhub, binderhub-service, repo2docker, jupyterhub, jupyter]

--- a/binderhub-service/templates/_helpers.tpl
+++ b/binderhub-service/templates/_helpers.tpl
@@ -1,14 +1,14 @@
-{{/*
-Expand the name of the chart.
+{{- /*
+  Expand the name of the chart.
 */}}
 {{- define "binderhub-service.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+{{- /*
+  Create a default fully qualified app name.
+  We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+  If release name contains chart name it will be used as a full name.
 */}}
 {{- define "binderhub-service.fullname" -}}
 {{- if .Values.fullnameOverride }}
@@ -23,15 +23,15 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
+{{- /*
+  Create chart name and version as used by the chart label.
 */}}
 {{- define "binderhub-service.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
-Common labels
+{{- /*
+  Common labels
 */}}
 {{- define "binderhub-service.labels" -}}
 helm.sh/chart: {{ include "binderhub-service.chart" . }}
@@ -42,22 +42,22 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
-{{/*
-Selector labels
+{{- /*
+  Selector labels
 */}}
 {{- define "binderhub-service.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "binderhub-service.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
-{{/*
-Create the name of the service account to use
+{{- /*
+  Create the name of the service account to use
 */}}
 {{- define "binderhub-service.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "binderhub-service.fullname" .) .Values.serviceAccount.name }}
+{{- include "binderhub-service.fullname" . | default .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 
@@ -68,7 +68,8 @@ Create the name of the service account to use
     Renders a valid git reference from a chartpress generated version string.
     In practice, either a git tag or a git commit hash will be returned.
 
-    - The version string will follow a chartpress pattern, see
+    - The version string will follow a chartpress pattern,
+      like "0.1.0-0.dev.git.17.h8368bc0", see
       https://github.com/jupyterhub/chartpress#examples-chart-versions-and-image-tags.
 
     - The regexReplaceAll function is a sprig library function, see
@@ -78,5 +79,5 @@ Create the name of the service account to use
       example.
 */}}
 {{- define "binderhub-service.chart-version-to-git-ref" -}}
-{{- regexReplaceAll ".*[.-]n\\d+[.]h(.*)" . "${1}" }}
+{{- regexReplaceAll ".*\\.git\\.\\d+\\.h(.*)" . "${1}" }}
 {{- end }}

--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "binderhub-service.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "binderhub-service.selectorLabels" . | nindent 6 }}
@@ -18,27 +18,30 @@ spec:
       labels:
         {{- include "binderhub-service.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- . | toYaml | nindent 8 }}
-      {{- end }}
-      serviceAccountName: {{ include "binderhub-service.serviceAccountName" . }}
-      securityContext:
-        {{- .Values.podSecurityContext | toYaml | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: binderhub
           securityContext:
             {{- .Values.securityContext | toYaml | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
-              protocol: TCP
           resources:
             {{- .Values.resources | toYaml | nindent 12 }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with include "binderhub-service.serviceAccountName" . }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- . | toYaml | nindent 8 }}

--- a/binderhub-service/templates/role.yaml
+++ b/binderhub-service/templates/role.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create -}}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "binderhub-service.fullname" . }}
+  labels:
+    {{- include "binderhub-service.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+{{- end }}

--- a/binderhub-service/templates/rolebinding.yaml
+++ b/binderhub-service/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "binderhub-service.fullname" . }}
+  labels:
+    {{- include "binderhub-service.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "binderhub-service.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "binderhub-service.fullname" . }}
+{{- end }}

--- a/binderhub-service/templates/service.yaml
+++ b/binderhub-service/templates/service.yaml
@@ -3,11 +3,14 @@ kind: Service
 metadata:
   name: {{ include "binderhub-service.fullname" . }}
   labels: {{- include "binderhub-service.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
       targetPort: http
-      protocol: TCP
-      name: http
   selector: {{- include "binderhub-service.selectorLabels" . | nindent 4 }}

--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -13,10 +13,23 @@
 #
 $schema: http://json-schema.org/draft-07/schema#
 type: object
-additionalProperties: true
+additionalProperties: false
 required:
+  # General configuration
+  - nameOverride
+  - fullnameOverride
   - global
+  # Deployment resource
+  - image
+  # Other resources
+  - rbac
+  - serviceAccount
+  - service
+  - ingress
 properties:
+  # General configuration
+  # ---------------------------------------------------------------------------
+  #
   nameOverride:
     type: string
   fullnameOverride:
@@ -24,3 +37,106 @@ properties:
   global:
     type: object
     additionalProperties: true
+
+  # Deployment resource
+  # ---------------------------------------------------------------------------
+  #
+  replicas:
+    type: integer
+  image:
+    type: object
+    additionalProperties: false
+    required: [repository, tag]
+    properties:
+      repository:
+        type: string
+      tag:
+        type: string
+      pullPolicy:
+        enum: [null, "", IfNotPresent, Always, Never]
+      pullSecrets:
+        type: array
+  resources:
+    type: object
+    additionalProperties: true
+  securityContext:
+    type: object
+    additionalProperties: true
+  podSecurityContext:
+    type: object
+    additionalProperties: true
+  podAnnotations: &labels-and-annotations
+    type: object
+    additionalProperties: false
+    patternProperties:
+      ".*":
+        type: string
+  nodeSelector:
+    type: object
+    additionalProperties: true
+  tolerations:
+    type: array
+  affinity:
+    type: object
+    additionalProperties: true
+
+  # RBAC resources
+  # ---------------------------------------------------------------------------
+  #
+  rbac:
+    type: object
+    additionalProperties: false
+    required: [create]
+    properties:
+      create:
+        type: boolean
+
+  # ServiceAccount resource
+  # ---------------------------------------------------------------------------
+  #
+  serviceAccount:
+    type: object
+    additionalProperties: false
+    required: [create, name]
+    properties:
+      create:
+        type: boolean
+      name:
+        type: string
+      annotations: *labels-and-annotations
+
+  # Service resource
+  # ---------------------------------------------------------------------------
+  #
+  service:
+    type: object
+    additionalProperties: false
+    required: [type, port]
+    properties:
+      type:
+        type: string
+      port:
+        type: integer
+      annotations: *labels-and-annotations
+
+  # Ingress resource
+  # ---------------------------------------------------------------------------
+  #
+  ingress:
+    type: object
+    additionalProperties: false
+    required: [enabled]
+    properties:
+      enabled:
+        type: boolean
+      className:
+        type: [string, "null"]
+      hosts:
+        type: array
+      pathSuffix:
+        type: [string, "null"]
+      pathType:
+        enum: [Prefix, Exact, ImplementationSpecific]
+      tls:
+        type: array
+      annotations: *labels-and-annotations

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -8,8 +8,7 @@ global: {}
 # Deployment resource
 # -----------------------------------------------------------------------------
 #
-replicaCount: 1
-
+replicas: 1
 image:
   repository: quay.io/2i2c/binderhub-service
   tag: "set-by-chartpress"
@@ -23,20 +22,25 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 resources: {}
-
 podAnnotations: {}
 podSecurityContext: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# RBAC resources
+# -----------------------------------------------------------------------------
+#
+rbac:
+  create: true
+
 # ServiceAccount resource
 # -----------------------------------------------------------------------------
 #
 serviceAccount:
   create: true
-  annotations: {}
   name: ""
+  annotations: {}
 
 # Service resource
 # -----------------------------------------------------------------------------

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -1,1 +1,39 @@
+# General configuration
+# -----------------------------------------------------------------------------
+#
+nameOverride: ""
+fullnameOverride: ""
 global: {}
+
+# Deployment resource
+# -----------------------------------------------------------------------------
+#
+image:
+  repository: quay.io/2i2c/binderhub-service
+  tag: "set-by-chartpress"
+
+# RBAC resources
+# -----------------------------------------------------------------------------
+#
+rbac:
+  create: true
+
+# ServiceAccount resource
+# -----------------------------------------------------------------------------
+#
+serviceAccount:
+  create: true
+  name: ""
+
+# Service resource
+# -----------------------------------------------------------------------------
+#
+service:
+  type: ClusterIP
+  port: 80
+
+# Ingress resource
+# -----------------------------------------------------------------------------
+#
+ingress:
+  enabled: false


### PR DESCRIPTION
- Closes #4

![image](https://user-images.githubusercontent.com/3837114/227639540-37917540-1e7b-44f9-a696-eef188217c75.png)

```
kubectl get all
NAME                                   READY   STATUS    RESTARTS   AGE
pod/binderhub-service-96c5696b-dcp6h   1/1     Running   0          21m

NAME                        TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
service/binderhub-service   ClusterIP   10.43.18.168   <none>        80/TCP    24m

NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/binderhub-service   1/1     1            1           24m

NAME                                           DESIRED   CURRENT   READY   AGE
replicaset.apps/binderhub-service-96c5696b     1         1         1       21m
```