### PR TITLE
Add docker-api daemonset, prepares k8s nodes for build pods' requirements

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -165,4 +165,4 @@ jobs:
       - uses: jupyterhub/action-k8s-namespace-report@v1
         if: always()
         with:
-          important-workloads: deploy/binderhub-service
+          important-workloads: deploy/binderhub-service daemonset/binderhub-service-docker-api

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -4,11 +4,16 @@
 # This Workflow watches dependencies and automatically creates PRs to update
 # them.
 #
+# - Watch multiple images tags referenced in values.yaml to match the latest
+#   stable image tag (ignoring pre-releases).
 # - Refreeze images/*/requirements.txt based on images/*/requirements.in
 #
 name: Watch dependencies
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/watch-dependencies.yaml"
   push:
     paths:
       - "images/*/requirements.in"
@@ -20,6 +25,65 @@ on:
   workflow_dispatch:
 
 jobs:
+  update-image-dependencies:
+    if: github.repository == '2i2c-org/binderhub-service'
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: docker
+            registry: docker.io
+            repository: library/docker
+            values_path: dockerApi.image.tag
+            tag_prefix: ""
+            tag_suffix: -dind
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get values.yaml pinned tag of ${{ matrix.registry }}/${{ matrix.repository }}
+        id: local
+        run: |
+          local_tag=$(cat binderhub-service/values.yaml | yq e '.${{ matrix.values_path }}' -)
+          echo "tag=$local_tag" >> $GITHUB_OUTPUT
+
+      - name: Get latest tag of ${{ matrix.registry }}/${{ matrix.repository }}
+        id: latest
+        # The skopeo image helps us list tags consistently from different docker
+        # registries. We identify the latest docker image tag based on the
+        # version numbers of format x.y.z included in a pattern with an optional
+        # prefix and suffix, like the tags "v4.5.0" (v prefix) and "23.0.4-dind"
+        # (-dind suffix).
+        run: |
+          latest_tag=$(
+              docker run --rm quay.io/skopeo/stable list-tags docker://${{ matrix.registry }}/${{ matrix.repository }} \
+            | jq -r '[.Tags[] | select(. | match("^${{ matrix.tag_prefix }}\\d+\\.\\d+\\.\\d+${{ matrix.tag_suffix }}$") | .string)] | sort_by(split(".") | map(ltrimstr("${{ matrix.tag_prefix }}") | rtrimstr("${{ matrix.tag_suffix }}") | tonumber)) | last'
+          )
+          echo "tag=$latest_tag" >> $GITHUB_OUTPUT
+
+      - name: Update values.yaml pinned tag
+        if: steps.local.outputs.tag != steps.latest.outputs.tag
+        run: |
+          sed --in-place 's/tag: "${{ steps.local.outputs.tag }}"/tag: "${{ steps.latest.outputs.tag }}"/g' binderhub-service/values.yaml
+
+      - name: git diff
+        if: steps.local.outputs.tag != steps.latest.outputs.tag
+        run: git --no-pager diff --color=always
+
+      # ref: https://github.com/peter-evans/create-pull-request
+      - uses: peter-evans/create-pull-request@v4
+        if: github.event_name != 'pull_request'
+        with:
+          branch: update-image-dependencies
+          labels: dependencies
+          commit-message: Update ${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
+          title: Update ${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
+          body: >-
+            A new ${{ matrix.repository }} image version has been detected, version
+            `${{ steps.latest.outputs.tag }}`.
+
   refreeze-dockerfile-requirements-txt:
     if: github.repository == '2i2c-org/binderhub-service'
     runs-on: ubuntu-22.04
@@ -38,6 +102,7 @@ jobs:
 
       # ref: https://github.com/peter-evans/create-pull-request
       - uses: peter-evans/create-pull-request@v4
+        if: github.event_name != 'pull_request'
         with:
           branch: update-image-requirements
           labels: dependencies

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -54,7 +54,7 @@ jobs:
         # The skopeo image helps us list tags consistently from different docker
         # registries. We identify the latest docker image tag based on the
         # version numbers of format x.y.z included in a pattern with an optional
-        # prefix and suffix, like the tags "v4.5.0" (v prefix) and "23.0.4-dind"
+        # prefix and suffix, like the tags "v4.5.0" (v prefix) and "23.0.5-dind"
         # (-dind suffix).
         run: |
           latest_tag=$(

--- a/binderhub-service/templates/_helpers.tpl
+++ b/binderhub-service/templates/_helpers.tpl
@@ -2,7 +2,7 @@
   Expand the name of the chart.
 */}}
 {{- define "binderhub-service.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Values.nameOverride | default .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{- /*
@@ -14,7 +14,7 @@
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := .Values.nameOverride | default .Chart.Name }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}

--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "binderhub-service.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: binderhub
   template:
     metadata:
       annotations:
@@ -18,6 +19,7 @@ spec:
         {{- end }}
       labels:
         {{- include "binderhub-service.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: binderhub
     spec:
       volumes:
         - name: secret

--- a/binderhub-service/templates/docker-api/daemonset.yaml
+++ b/binderhub-service/templates/docker-api/daemonset.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "binderhub-service.fullname" . }}-docker-api
+  labels:
+    {{- include "binderhub-service.labels" . | nindent 4 }}
+    app.kubernetes.io/component: docker-api
+spec:
+  selector:
+    matchLabels:
+      {{- include "binderhub-service.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: docker-api
+  template:
+    metadata:
+      labels:
+        {{- include "binderhub-service.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: docker-api
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: docker-api
+          image: {{ .Values.dockerApi.image.repository }}:{{ .Values.dockerApi.image.tag }}
+          args:
+            - dockerd
+            - --data-root=/var/lib/docker-api
+            - --exec-root=/var/run/docker-api
+            - --host=unix://var/run/docker-api/docker-api.sock
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/docker-api
+            - name: exec
+              mountPath: /var/run/docker-api
+          resources:
+            {{- .Values.dockerApi.resources | toYaml | nindent 12 }}
+          securityContext:
+            {{- .Values.dockerApi.securityContext | toYaml | nindent 12 }}
+      volumes:
+        - name: data
+          hostPath:
+            path: /var/lib/docker-api
+            type: DirectoryOrCreate
+        - name: exec
+          hostPath:
+            path: /var/run/docker-api
+            type: DirectoryOrCreate
+      {{- with .Values.dockerApi.image.pullSecrets }}
+      imagePullSecrets:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dockerApi.podSecurityContext }}
+      securityContext:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dockerApi.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dockerApi.affinity }}
+      affinity:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dockerApi.tolerations }}
+      tolerations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}

--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -41,7 +41,6 @@ properties:
   # Deployment resource
   # ---------------------------------------------------------------------------
   #
-
   config:
     type: object
     additionalProperties: false
@@ -58,7 +57,7 @@ properties:
 
   replicas:
     type: integer
-  image:
+  image: &image
     type: object
     additionalProperties: false
     required: [repository, tag]
@@ -71,13 +70,13 @@ properties:
         enum: [null, "", IfNotPresent, Always, Never]
       pullSecrets:
         type: array
-  resources:
+  resources: &resources
     type: object
     additionalProperties: true
-  securityContext:
+  securityContext: &securityContext
     type: object
     additionalProperties: true
-  podSecurityContext:
+  podSecurityContext: &podSecurityContext
     type: object
     additionalProperties: true
   podAnnotations: &labels-and-annotations
@@ -86,14 +85,14 @@ properties:
     patternProperties:
       ".*":
         type: string
-  nodeSelector:
+  nodeSelector: &nodeSelector
     type: object
     additionalProperties: true
-  tolerations:
+  affinity: &affinity
+    type: object
+    additionalProperties: true
+  tolerations: &tolerations
     type: array
-  affinity:
-    type: object
-    additionalProperties: true
 
   # RBAC resources
   # ---------------------------------------------------------------------------
@@ -155,3 +154,20 @@ properties:
       tls:
         type: array
       annotations: *labels-and-annotations
+
+  # DaemonSet resource - docker-api
+  # ---------------------------------------------------------------------------
+  #
+  dockerApi:
+    type: object
+    additionalProperties: false
+    required: [image]
+    properties:
+      image: *image
+      resources: *resources
+      securityContext: *securityContext
+      podSecurityContext: *podSecurityContext
+      podAnnotations: *labels-and-annotations
+      nodeSelector: *nodeSelector
+      affinity: *affinity
+      tolerations: *tolerations

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -22,7 +22,8 @@ config:
   BinderHub:
     base_url: /
     use_registry: true
-  KubernetesBuildExecutor: {}
+  KubernetesBuildExecutor:
+    docker_host: /var/run/docker-api/docker-api.sock
 extraConfig: {}
 
 replicas: 1
@@ -31,6 +32,7 @@ image:
   tag: "set-by-chartpress"
   pullPolicy: ""
   pullSecrets: []
+resources: {}
 securityContext:
   capabilities:
     drop:
@@ -38,12 +40,12 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
-resources: {}
-podAnnotations: {}
+
 podSecurityContext: {}
+podAnnotations: {}
 nodeSelector: {}
-tolerations: []
 affinity: {}
+tolerations: []
 
 # RBAC resources
 # -----------------------------------------------------------------------------
@@ -79,3 +81,27 @@ ingress:
         - path: /
           pathType: ImplementationSpecific
   tls: []
+
+# DaemonSet resource - docker-api
+# -----------------------------------------------------------------------------
+#
+# This DaemonSet starts a pod on each node to setup a Docker API that
+# binderhub's spawned build pods can make use of, via a hostPath volume that
+# exposes a unix socket.
+#
+dockerApi:
+  image:
+    repository: docker.io/library/docker
+    tag: "23.0.4-dind" # ref: https://hub.docker.com/_/docker/tags
+    pullPolicy: ""
+    pullSecrets: []
+  resources: {}
+  securityContext:
+    privileged: true
+    runAsUser: 0
+
+  podSecurityContext: {}
+  podAnnotations: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -92,7 +92,7 @@ ingress:
 dockerApi:
   image:
     repository: docker.io/library/docker
-    tag: "23.0.4-dind" # ref: https://hub.docker.com/_/docker/tags
+    tag: "23.0.5-dind" # ref: https://hub.docker.com/_/docker/tags
     pullPolicy: ""
     pullSecrets: []
   resources: {}

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -44,7 +44,7 @@ ingress:
 dockerApi:
   image:
     repository: docker.io/library/docker
-    tag: "23.0.4-dind"
+    tag: "23.0.5-dind"
   securityContext:
     privileged: true
     runAsUser: 0

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -37,3 +37,14 @@ service:
 #
 ingress:
   enabled: false
+
+# DaemonSet resource - docker-api
+# -----------------------------------------------------------------------------
+#
+dockerApi:
+  image:
+    repository: docker.io/library/docker
+    tag: "23.0.4-dind"
+  securityContext:
+    privileged: true
+    runAsUser: 0


### PR DESCRIPTION
- Closes #21 

```
kubectl get pod
NAME                                 READY   STATUS    RESTARTS   AGE
binderhub-service-6cc6bf8759-8gg56   1/1     Running   0          91m
binderhub-service-docker-api-gg8jh   1/1     Running   0          14m
```

### Logs from docker-api container startup

<details>
<summary>Click to expand</summary>

```
time="2023-04-27T07:01:38.986153752Z" level=info msg="Starting up"
time="2023-04-27T07:01:38.987350908Z" level=warning msg="could not change group var/run/docker-api/docker-api.sock to docker: group docker not found"
time="2023-04-27T07:01:38.988272789Z" level=info msg="libcontainerd: started new containerd process" pid=99
time="2023-04-27T07:01:38.988478801Z" level=info msg="[core] [Channel #1] Channel created" module=grpc
time="2023-04-27T07:01:38.988615510Z" level=info msg="[core] [Channel #1] original dial target is: \"unix:///var/run/docker-api/containerd/containerd.sock\"" module=grpc
time="2023-04-27T07:01:38.988744268Z" level=info msg="[core] [Channel #1] parsed dial target is: {Scheme:unix Authority: Endpoint:var/run/docker-api/containerd/containerd.sock URL:{Scheme:unix Opaque: User: Host: Path:/var/run/docker-api/containerd/containerd.sock RawPath: OmitHost:false ForceQuery:false RawQuery: Fragment: RawFragment:}}" module=grpc
time="2023-04-27T07:01:38.988850527Z" level=info msg="[core] [Channel #1] Channel authority set to \"localhost\"" module=grpc
time="2023-04-27T07:01:38.989093230Z" level=info msg="[core] [Channel #1] Resolver state updated: {\n  \"Addresses\": [\n    {\n      \"Addr\": \"/var/run/docker-api/containerd/containerd.sock\",\n      \"ServerName\": \"\",\n      \"Attributes\": {},\n      \"BalancerAttributes\": null,\n      \"Type\": 0,\n      \"Metadata\": null\n    }\n  ],\n  \"ServiceConfig\": null,\n  \"Attributes\": null\n} (resolver returned new addresses)" module=grpc
time="2023-04-27T07:01:38.989240997Z" level=info msg="[core] [Channel #1] Channel switches to new LB policy \"pick_first\"" module=grpc
time="2023-04-27T07:01:38.989384678Z" level=info msg="[core] [Channel #1 SubChannel #2] Subchannel created" module=grpc
time="2023-04-27T07:01:38.989505554Z" level=info msg="[core] [Channel #1 SubChannel #2] Subchannel Connectivity change to CONNECTING" module=grpc
time="2023-04-27T07:01:38.989621616Z" level=info msg="[core] [Channel #1 SubChannel #2] Subchannel picks a new address \"/var/run/docker-api/containerd/containerd.sock\" to connect" module=grpc
time="2023-04-27T07:01:38.989894325Z" level=info msg="[core] [Channel #1] Channel Connectivity change to CONNECTING" module=grpc
time="2023-04-27T07:01:39.008716624Z" level=info msg="starting containerd" revision=2806fc1057397dbaeefbea0e4e17bddfbd388f38 version=v1.6.20
time="2023-04-27T07:01:39.021305418Z" level=info msg="loading plugin \"io.containerd.content.v1.content\"..." type=io.containerd.content.v1
time="2023-04-27T07:01:39.021562890Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.aufs\"..." type=io.containerd.snapshotter.v1
time="2023-04-27T07:01:39.025885517Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.aufs\"..." error="aufs is not supported (modprobe aufs failed: exit status 1 \"ip: can't find device 'aufs'\\nmodprobe: can't change directory to '/lib/modules': No such file or directory\\n\"): skip plugin" type=io.containerd.snapshotter.v1
time="2023-04-27T07:01:39.026003501Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.devmapper\"..." type=io.containerd.snapshotter.v1
time="2023-04-27T07:01:39.026069484Z" level=warning msg="failed to load plugin io.containerd.snapshotter.v1.devmapper" error="devmapper not configured"
time="2023-04-27T07:01:39.026107064Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.native\"..." type=io.containerd.snapshotter.v1
time="2023-04-27T07:01:39.026240946Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.overlayfs\"..." type=io.containerd.snapshotter.v1
time="2023-04-27T07:01:39.026512586Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.zfs\"..." type=io.containerd.snapshotter.v1
time="2023-04-27T07:01:39.026717156Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.zfs\"..." error="path /var/lib/docker-api/containerd/daemon/io.containerd.snapshotter.v1.zfs must be a zfs filesystem to be used with the zfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
time="2023-04-27T07:01:39.026787983Z" level=info msg="loading plugin \"io.containerd.metadata.v1.bolt\"..." type=io.containerd.metadata.v1
time="2023-04-27T07:01:39.026881798Z" level=warning msg="could not use snapshotter devmapper in metadata plugin" error="devmapper not configured"
time="2023-04-27T07:01:39.026924765Z" level=info msg="metadata content store policy set" policy=shared
time="2023-04-27T07:01:39.033191957Z" level=info msg="loading plugin \"io.containerd.differ.v1.walking\"..." type=io.containerd.differ.v1
time="2023-04-27T07:01:39.033303948Z" level=info msg="loading plugin \"io.containerd.event.v1.exchange\"..." type=io.containerd.event.v1
time="2023-04-27T07:01:39.033390327Z" level=info msg="loading plugin \"io.containerd.gc.v1.scheduler\"..." type=io.containerd.gc.v1
time="2023-04-27T07:01:39.033669004Z" level=info msg="loading plugin \"io.containerd.service.v1.introspection-service\"..." type=io.containerd.service.v1
time="2023-04-27T07:01:39.033812515Z" level=info msg="loading plugin \"io.containerd.service.v1.containers-service\"..." type=io.containerd.service.v1
time="2023-04-27T07:01:39.033876751Z" level=info msg="loading plugin \"io.containerd.service.v1.content-service\"..." type=io.containerd.service.v1
time="2023-04-27T07:01:39.033931874Z" level=info msg="loading plugin \"io.containerd.service.v1.diff-service\"..." type=io.containerd.service.v1
time="2023-04-27T07:01:39.033978506Z" level=info msg="loading plugin \"io.containerd.service.v1.images-service\"..." type=io.containerd.service.v1
time="2023-04-27T07:01:39.034037297Z" level=info msg="loading plugin \"io.containerd.service.v1.leases-service\"..." type=io.containerd.service.v1
time="2023-04-27T07:01:39.034083693Z" level=info msg="loading plugin \"io.containerd.service.v1.namespaces-service\"..." type=io.containerd.service.v1
time="2023-04-27T07:01:39.034137536Z" level=info msg="loading plugin \"io.containerd.service.v1.snapshots-service\"..." type=io.containerd.service.v1
time="2023-04-27T07:01:39.034183792Z" level=info msg="loading plugin \"io.containerd.runtime.v1.linux\"..." type=io.containerd.runtime.v1
time="2023-04-27T07:01:39.034340366Z" level=info msg="loading plugin \"io.containerd.runtime.v2.task\"..." type=io.containerd.runtime.v2
time="2023-04-27T07:01:39.034491092Z" level=info msg="loading plugin \"io.containerd.monitor.v1.cgroups\"..." type=io.containerd.monitor.v1
time="2023-04-27T07:01:39.034779102Z" level=info msg="loading plugin \"io.containerd.service.v1.tasks-service\"..." type=io.containerd.service.v1
time="2023-04-27T07:01:39.034897940Z" level=info msg="loading plugin \"io.containerd.grpc.v1.introspection\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.034956128Z" level=info msg="loading plugin \"io.containerd.internal.v1.restart\"..." type=io.containerd.internal.v1
time="2023-04-27T07:01:39.035036874Z" level=info msg="loading plugin \"io.containerd.grpc.v1.containers\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.035154335Z" level=info msg="loading plugin \"io.containerd.grpc.v1.content\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.035206919Z" level=info msg="loading plugin \"io.containerd.grpc.v1.diff\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.035261878Z" level=info msg="loading plugin \"io.containerd.grpc.v1.events\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.035307892Z" level=info msg="loading plugin \"io.containerd.grpc.v1.healthcheck\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.035366203Z" level=info msg="loading plugin \"io.containerd.grpc.v1.images\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.035410351Z" level=info msg="loading plugin \"io.containerd.grpc.v1.leases\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.035451624Z" level=info msg="loading plugin \"io.containerd.grpc.v1.namespaces\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.035508874Z" level=info msg="loading plugin \"io.containerd.internal.v1.opt\"..." type=io.containerd.internal.v1
time="2023-04-27T07:01:39.035825006Z" level=info msg="loading plugin \"io.containerd.grpc.v1.snapshots\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.035905970Z" level=info msg="loading plugin \"io.containerd.grpc.v1.tasks\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.035969168Z" level=info msg="loading plugin \"io.containerd.grpc.v1.version\"..." type=io.containerd.grpc.v1
time="2023-04-27T07:01:39.036009604Z" level=info msg="loading plugin \"io.containerd.tracing.processor.v1.otlp\"..." type=io.containerd.tracing.processor.v1
time="2023-04-27T07:01:39.036074335Z" level=info msg="skip loading plugin \"io.containerd.tracing.processor.v1.otlp\"..." error="no OpenTelemetry endpoint: skip plugin" type=io.containerd.tracing.processor.v1
time="2023-04-27T07:01:39.036114477Z" level=info msg="loading plugin \"io.containerd.internal.v1.tracing\"..." type=io.containerd.internal.v1
time="2023-04-27T07:01:39.036182301Z" level=error msg="failed to initialize a tracing processor \"otlp\"" error="no OpenTelemetry endpoint: skip plugin"
time="2023-04-27T07:01:39.036459906Z" level=info msg=serving... address=/var/run/docker-api/containerd/containerd-debug.sock
time="2023-04-27T07:01:39.036622957Z" level=info msg=serving... address=/var/run/docker-api/containerd/containerd.sock.ttrpc
time="2023-04-27T07:01:39.036763083Z" level=info msg=serving... address=/var/run/docker-api/containerd/containerd.sock
time="2023-04-27T07:01:39.037756033Z" level=info msg="containerd successfully booted in 0.029743s"
time="2023-04-27T07:01:39.043715468Z" level=info msg="[core] [Channel #1 SubChannel #2] Subchannel Connectivity change to READY" module=grpc
time="2023-04-27T07:01:39.043883636Z" level=info msg="[core] [Channel #1] Channel Connectivity change to READY" module=grpc
time="2023-04-27T07:01:39.046173010Z" level=info msg="[core] [Channel #4] Channel created" module=grpc
time="2023-04-27T07:01:39.047244588Z" level=info msg="[core] [Channel #4] original dial target is: \"unix:///var/run/docker-api/containerd/containerd.sock\"" module=grpc
time="2023-04-27T07:01:39.047299985Z" level=info msg="[core] [Channel #4] parsed dial target is: {Scheme:unix Authority: Endpoint:var/run/docker-api/containerd/containerd.sock URL:{Scheme:unix Opaque: User: Host: Path:/var/run/docker-api/containerd/containerd.sock RawPath: OmitHost:false ForceQuery:false RawQuery: Fragment: RawFragment:}}" module=grpc
time="2023-04-27T07:01:39.047328453Z" level=info msg="[core] [Channel #4] Channel authority set to \"localhost\"" module=grpc
time="2023-04-27T07:01:39.047898167Z" level=info msg="[core] [Channel #4] Resolver state updated: {\n  \"Addresses\": [\n    {\n      \"Addr\": \"/var/run/docker-api/containerd/containerd.sock\",\n      \"ServerName\": \"\",\n      \"Attributes\": {},\n      \"BalancerAttributes\": null,\n      \"Type\": 0,\n      \"Metadata\": null\n    }\n  ],\n  \"ServiceConfig\": null,\n  \"Attributes\": null\n} (resolver returned new addresses)" module=grpc
time="2023-04-27T07:01:39.048192450Z" level=info msg="[core] [Channel #4] Channel switches to new LB policy \"pick_first\"" module=grpc
time="2023-04-27T07:01:39.048317873Z" level=info msg="[core] [Channel #4 SubChannel #5] Subchannel created" module=grpc
time="2023-04-27T07:01:39.048396353Z" level=info msg="[core] [Channel #4 SubChannel #5] Subchannel Connectivity change to CONNECTING" module=grpc
time="2023-04-27T07:01:39.048492059Z" level=info msg="[core] [Channel #4 SubChannel #5] Subchannel picks a new address \"/var/run/docker-api/containerd/containerd.sock\" to connect" module=grpc
time="2023-04-27T07:01:39.049381064Z" level=info msg="[core] [Channel #4] Channel Connectivity change to CONNECTING" module=grpc
time="2023-04-27T07:01:39.050049262Z" level=info msg="[core] [Channel #4 SubChannel #5] Subchannel Connectivity change to READY" module=grpc
time="2023-04-27T07:01:39.050134755Z" level=info msg="[core] [Channel #4] Channel Connectivity change to READY" module=grpc
time="2023-04-27T07:01:39.052603885Z" level=info msg="[core] [Channel #7] Channel created" module=grpc
time="2023-04-27T07:01:39.052676334Z" level=info msg="[core] [Channel #7] original dial target is: \"unix:///var/run/docker-api/containerd/containerd.sock\"" module=grpc
time="2023-04-27T07:01:39.052766099Z" level=info msg="[core] [Channel #7] parsed dial target is: {Scheme:unix Authority: Endpoint:var/run/docker-api/containerd/containerd.sock URL:{Scheme:unix Opaque: User: Host: Path:/var/run/docker-api/containerd/containerd.sock RawPath: OmitHost:false ForceQuery:false RawQuery: Fragment: RawFragment:}}" module=grpc
time="2023-04-27T07:01:39.052906664Z" level=info msg="[core] [Channel #7] Channel authority set to \"localhost\"" module=grpc
time="2023-04-27T07:01:39.053012839Z" level=info msg="[core] [Channel #7] Resolver state updated: {\n  \"Addresses\": [\n    {\n      \"Addr\": \"/var/run/docker-api/containerd/containerd.sock\",\n      \"ServerName\": \"\",\n      \"Attributes\": {},\n      \"BalancerAttributes\": null,\n      \"Type\": 0,\n      \"Metadata\": null\n    }\n  ],\n  \"ServiceConfig\": null,\n  \"Attributes\": null\n} (resolver returned new addresses)" module=grpc
time="2023-04-27T07:01:39.053097699Z" level=info msg="[core] [Channel #7] Channel switches to new LB policy \"pick_first\"" module=grpc
time="2023-04-27T07:01:39.053203995Z" level=info msg="[core] [Channel #7 SubChannel #8] Subchannel created" module=grpc
time="2023-04-27T07:01:39.053286557Z" level=info msg="[core] [Channel #7 SubChannel #8] Subchannel Connectivity change to CONNECTING" module=grpc
time="2023-04-27T07:01:39.053456250Z" level=info msg="[core] [Channel #7 SubChannel #8] Subchannel picks a new address \"/var/run/docker-api/containerd/containerd.sock\" to connect" module=grpc
time="2023-04-27T07:01:39.054251571Z" level=info msg="[core] [Channel #7] Channel Connectivity change to CONNECTING" module=grpc
time="2023-04-27T07:01:39.054357584Z" level=info msg="[core] [Channel #7 SubChannel #8] Subchannel Connectivity change to READY" module=grpc
time="2023-04-27T07:01:39.054422204Z" level=info msg="[core] [Channel #7] Channel Connectivity change to READY" module=grpc
time="2023-04-27T07:01:41.016666573Z" level=info msg="Loading containers: start."
time="2023-04-27T07:01:41.102239528Z" level=info msg="Loading containers: done."
time="2023-04-27T07:01:41.112214919Z" level=info msg="Docker daemon" commit=cbce331 graphdriver=overlay2 version=23.0.4
time="2023-04-27T07:01:41.112452818Z" level=info msg="Daemon has completed initialization"
time="2023-04-27T07:01:41.125100374Z" level=info msg="[core] [Server #10] Server created" module=grpc
time="2023-04-27T07:01:41.129470027Z" level=info msg="API listen on var/run/docker-api/docker-api.sock"
```

</details>