### PR TITLE
Add startupProbe, set BinderHub.require_build_only=true, and fix details

### DIFF
--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
             {{- .Values.resources | toYaml | nindent 12 }}
           securityContext:
             {{- .Values.securityContext | toYaml | nindent 12 }}
+          startupProbe:
+            periodSeconds: 1
+            failureThreshold: 60
+            httpGet:
+              path: {{ .Values.config.BinderHub.base_url }}/versions
+              port: http
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- . | toYaml | nindent 8 }}

--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.config.BinderHub.port }}
           volumeMounts:
             - name: secret
               mountPath: /etc/binderhub/mounted-secret/

--- a/binderhub-service/templates/docker-api/daemonset.yaml
+++ b/binderhub-service/templates/docker-api/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
             - dockerd
             - --data-root=/var/lib/docker-api
             - --exec-root=/var/run/docker-api
-            - --host=unix://var/run/docker-api/docker-api.sock
+            - --host=unix:///var/run/docker-api/docker-api.sock
           volumeMounts:
             - name: data
               mountPath: /var/lib/docker-api

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -21,6 +21,7 @@ global: {}
 config:
   BinderHub:
     base_url: /
+    port: 8585
     use_registry: true
   KubernetesBuildExecutor:
     docker_host: /var/run/docker-api/docker-api.sock

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -29,6 +29,7 @@ config:
     base_url: /
     port: 8585
     use_registry: true
+    require_build_only: true
   KubernetesBuildExecutor:
     # docker_host must not be updated, assumptions about it are hardcoded in
     # docker-api/daemonset.yaml

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -18,6 +18,12 @@ global: {}
 # config.X.y sets c.X.y where X is a class and y is a configurable traitlet on
 # the class.
 #
+# Some config must be set here, and not via extraConfig, as its referenced by
+# the chart's template directly.
+#
+# - BinderHub.base_url (readinessProbe)
+# - BinderHub.port (containerPort)
+#
 config:
   BinderHub:
     base_url: /

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -24,6 +24,8 @@ config:
     port: 8585
     use_registry: true
   KubernetesBuildExecutor:
+    # docker_host must not be updated, assumptions about it are hardcoded in
+    # docker-api/daemonset.yaml
     docker_host: /var/run/docker-api/docker-api.sock
 extraConfig: {}
 


### PR DESCRIPTION
- Closes #17

By declaring a startupProbe, we get the key thing I wanted with #17. It allows our tests to fail if the pod fails to startup, because the pod will not become "Ready" until after startupProbe has succeeded. At the same time, we avoid making several requests to `/versions` etc after startup which could clutter debug logs etc.

The only point of readinessProbe is if we have multiple replicas, and want to handle our pod crashing unepxectedly, allowing other pods to take the load alone for a while. Similarly, the livenessProbe is a followup to failing readinessProbe, where it would restart itself if it failed unexpectedly for a longer duration.

For now, let's not include such things and settle for whats important - ensuring successful startup before entering Ready state - to help us catch issues.