### PR TITLE
Add ability to pass docker config and included registry credentials to build pods' docker clients, test builds and pushes, and add dockerApi.[extraArgs|extraFiles] to help testing

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -182,7 +182,9 @@ jobs:
           helm upgrade --install binderhub-service ./binderhub-service \
               --values dev-config.yaml \
               --set config.BinderHub.image_prefix=$LOCAL_REGISTRY_HOST/binderhub-service/ \
-              --set buildPodsRegistryCredentials.server=http://$LOCAL_REGISTRY_HOST
+              --set config.DockerRegistry.url=http://$LOCAL_REGISTRY_HOST \
+              --set buildPodsRegistryCredentials.server=http://$LOCAL_REGISTRY_HOST \
+              --set dockerApi.extraFiles.daemon-json.data.insecure-registries[0]=$LOCAL_REGISTRY_HOST
 
       # ref: https://github.com/jupyterhub/action-k8s-await-workloads
       - uses: jupyterhub/action-k8s-await-workloads@v2

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -190,6 +190,11 @@ jobs:
           timeout: 150
           max-restarts: 1
 
+      - name: Test image build/push via binderhub REST API using curl
+        run: |
+          kubectl port-forward deploy/binderhub-service 8585 &
+          curl http://localhost:8585/build/gh/binderhub-ci-repos/cached-minimal-dockerfile/HEAD?build_only=true
+
       # ref: https://github.com/jupyterhub/action-k8s-namespace-report
       - uses: jupyterhub/action-k8s-namespace-report@v1
         if: always()

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -192,8 +192,7 @@ jobs:
 
       - name: Test image build/push via binderhub REST API using curl
         run: |
-          kubectl port-forward deploy/binderhub-service 8585 &
-          curl http://localhost:8585/build/gh/binderhub-ci-repos/cached-minimal-dockerfile/HEAD?build_only=true
+          curl http://localhost:30080/build/gh/binderhub-ci-repos/cached-minimal-dockerfile/HEAD?build_only=true
 
       # ref: https://github.com/jupyterhub/action-k8s-namespace-report
       - uses: jupyterhub/action-k8s-namespace-report@v1

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -94,6 +94,14 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
 
+    # Start a local container registry that the binderhub build pods can push
+    # to, and the k8s cluster can pull images from for use by pods.
+    services:
+      registry:
+        image: docker.io/library/registry:latest
+        ports:
+          - 5000:5000
+
     strategy:
       fail-fast: false
       matrix:
@@ -107,12 +115,30 @@ jobs:
         include:
           - k3s-channel: latest
           - k3s-channel: stable
+          - k3s-channel: v1.24
 
     steps:
       - uses: actions/checkout@v3
         with:
           # chartpress needs git history
           fetch-depth: 0
+
+      - name: Determine how to reference local container registry
+        run: |
+          LOCAL_REGISTRY_HOST=$(hostname --all-ip-addresses | awk '{print $1}'):5000
+          echo LOCAL_REGISTRY_HOST="$LOCAL_REGISTRY_HOST" >> $GITHUB_ENV
+
+      - name: Configure k3s to pull from local container registry
+        run: |
+          # Allow k3s to pull from private registry
+          # https://docs.k3s.io/installation/private-registry
+          sudo mkdir -p /etc/rancher/k3s/
+          cat << EOF | sudo tee /etc/rancher/k3s/registries.yaml
+          mirrors:
+            "$LOCAL_REGISTRY_HOST":
+              endpoint:
+                - "http://$LOCAL_REGISTRY_HOST"
+          EOF
 
       # Starts a k8s cluster with NetworkPolicy enforcement and installs both
       # kubectl and helm
@@ -128,11 +154,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-
       - name: Install dependencies
         run: |
           pip install -r dev-requirements.txt
-          pip list
+      - name: List dependencies
+        run: |
+          pip freeze
 
       # Build our images if needed and update Chart.yaml and values.yaml with
       # version and tags
@@ -153,7 +180,9 @@ jobs:
       - name: Install local chart
         run: |
           helm upgrade --install binderhub-service ./binderhub-service \
-              --values dev-config.yaml
+              --values dev-config.yaml \
+              --set config.BinderHub.image_prefix=$LOCAL_REGISTRY_HOST/binderhub-service/ \
+              --set buildPodsRegistryCredentials.server=http://$LOCAL_REGISTRY_HOST
 
       # ref: https://github.com/jupyterhub/action-k8s-await-workloads
       - uses: jupyterhub/action-k8s-await-workloads@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@
 binderhub-service/values.schema.json
 tools/templates/rendered-templates/
 
+# convenience for storing production config in the repo while developing
+prod-config.yaml
 
-### Other misc things
-
+# Other misc things
 .vscode
 *.DS_Store
 

--- a/binderhub-service/templates/_helpers-extra-files.tpl
+++ b/binderhub-service/templates/_helpers-extra-files.tpl
@@ -1,0 +1,72 @@
+{{- /*
+  binderhub-service.extraFiles.data:
+    Renders content for a k8s Secret's data field, coming from extraFiles with
+    binaryData entries.
+*/}}
+{{- define "binderhub-service.extraFiles.data.withNewLineSuffix" -}}
+    {{- range $file_key, $file_details := . }}
+        {{- include "binderhub-service.extraFiles.validate-file" (list $file_key $file_details) }}
+        {{- if $file_details.binaryData }}
+            {{- $file_key | quote }}: {{ $file_details.binaryData | nospace | quote }}{{ println }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+{{- define "binderhub-service.extraFiles.data" -}}
+    {{- include "binderhub-service.extraFiles.data.withNewLineSuffix" . | trimSuffix "\n" }}
+{{- end }}
+
+{{- /*
+  binderhub-service.extraFiles.stringData:
+    Renders content for a k8s Secret's stringData field, coming from extraFiles
+    with either data or stringData entries.
+*/}}
+{{- define "binderhub-service.extraFiles.stringData.withNewLineSuffix" -}}
+    {{- range $file_key, $file_details := . }}
+        {{- include "binderhub-service.extraFiles.validate-file" (list $file_key $file_details) }}
+        {{- $file_name := $file_details.mountPath | base }}
+        {{- if $file_details.stringData }}
+            {{- $file_key | quote }}: |
+              {{- $file_details.stringData | trimSuffix "\n" | nindent 2 }}{{ println }}
+        {{- end }}
+        {{- if $file_details.data }}
+            {{- $file_key | quote }}: |
+              {{- if or (eq (ext $file_name) ".yaml") (eq (ext $file_name) ".yml") }}
+              {{- $file_details.data | toYaml | nindent 2 }}{{ println }}
+              {{- else if eq (ext $file_name) ".json" }}
+              {{- $file_details.data | toJson | nindent 2 }}{{ println }}
+              {{- else if eq (ext $file_name) ".toml" }}
+              {{- $file_details.data | toToml | trimSuffix "\n" | nindent 2 }}{{ println }}
+              {{- else }}
+              {{- print "\n\nextraFiles entries with 'data' (" $file_key " > " $file_details.mountPath ") needs to have a filename extension of .yaml, .yml, .json, or .toml!" | fail }}
+              {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+{{- define "binderhub-service.extraFiles.stringData" -}}
+    {{- include "binderhub-service.extraFiles.stringData.withNewLineSuffix" . | trimSuffix "\n" }}
+{{- end }}
+
+{{- define "binderhub-service.extraFiles.validate-file" -}}
+    {{- $file_key := index . 0 }}
+    {{- $file_details := index . 1 }}
+
+    {{- /* Use of mountPath. */}}
+    {{- if not ($file_details.mountPath) }}
+        {{- print "\n\nextraFiles entries (" $file_key ") must contain the field 'mountPath'." | fail }}
+    {{- end }}
+
+    {{- /* Use one of stringData, binaryData, data. */}}
+    {{- $field_count := 0 }}
+    {{- if $file_details.data }}
+        {{- $field_count = add1 $field_count }}
+    {{- end }}
+    {{- if $file_details.stringData }}
+        {{- $field_count = add1 $field_count }}
+    {{- end }}
+    {{- if $file_details.binaryData }}
+        {{- $field_count = add1 $field_count }}
+    {{- end }}
+    {{- if ne $field_count 1 }}
+        {{- print "\n\nextraFiles entries (" $file_key ") must only contain one of the fields: 'data', 'stringData', and 'binaryData'." | fail }}
+    {{- end }}
+{{- end }}

--- a/binderhub-service/templates/build-pods-docker-config/secret.yaml
+++ b/binderhub-service/templates/build-pods-docker-config/secret.yaml
@@ -1,0 +1,50 @@
+# This Secret is mounted by BinderHub's managed build pods because
+# c.KubernetesBuildExecutor.push_secret is configured with this Secret's name.
+#
+# IMPORTANT: This is _not_ a Kubernetes imagePullSecrets formatted Secret, it
+#            instead provides a config file for a docker client.
+#
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "binderhub-service.fullname" . }}-build-pods-docker-config
+  labels:
+    {{- include "binderhub-service.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # config.json refers to docker config that should house credentials for the
+  # docker client in a build pod to use against the docker-api.
+  #
+  # Docker's config.json expects something like below, where the xx...xx= string
+  # is "<username>:<password>" base64 encoded.
+  #
+  # {
+  #   "auths": {
+  #     "https://index.docker.io/v1/": {
+  #       "auth": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
+  #     }
+  #   }
+  # }
+  #
+  # ref: https://github.com/jupyterhub/binderhub/blob/79c5f61a992010f108637e3c434d9e606a3c8f72/binderhub/build.py#L397-L406
+  #
+  {{- /* initialize a dict to represent a docker client config */}}
+  {{- $dockerConfig := dict }}
+
+  {{- $server := .Values.buildPodsRegistryCredentials.server }}
+  {{- $username := .Values.buildPodsRegistryCredentials.username }}
+  {{- $password := .Values.buildPodsRegistryCredentials.password }}
+  {{- $blob := printf "%s:%s" $username $password | b64enc }}
+  {{- $credentials := dict "auths" (dict $server (dict "auth" $blob)) }}
+
+  {{- /* merge docker client config with registry credentials */}}
+  {{- if .Values.config.BinderHub.use_registry }}
+  {{- $dockerConfig = merge $dockerConfig $credentials }}
+  {{- end }}
+
+  {{- /* merge docker client config of any kind */}}
+  {{- if .Values.buildPodsDockerConfig }}
+  {{- $dockerConfig = merge $dockerConfig .Values.buildPodsDockerConfig }}
+  {{- end }}
+  config.json: |
+    {{- $dockerConfig | toPrettyJson | nindent 4 }}

--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
             - name: secret
               mountPath: /etc/binderhub/mounted-secret/
               readOnly: true
+          env:
+            - name: HELM_RELEASE_NAME
+              value: {{ .Release.Name }}
           resources:
             {{- .Values.resources | toYaml | nindent 12 }}
           securityContext:

--- a/binderhub-service/templates/docker-api/daemonset.yaml
+++ b/binderhub-service/templates/docker-api/daemonset.yaml
@@ -28,11 +28,19 @@ spec:
             - --data-root=/var/lib/docker-api
             - --exec-root=/var/run/docker-api
             - --host=unix:///var/run/docker-api/docker-api.sock
+            {{- with .Values.dockerApi.extraArgs }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: data
               mountPath: /var/lib/docker-api
             - name: exec
               mountPath: /var/run/docker-api
+            {{- range $file_key, $file_details := .Values.dockerApi.extraFiles }}
+            - name: files
+              mountPath: {{ $file_details.mountPath }}
+              subPath: {{ $file_key | quote }}
+            {{- end }}
           resources:
             {{- .Values.dockerApi.resources | toYaml | nindent 12 }}
           securityContext:
@@ -46,6 +54,19 @@ spec:
           hostPath:
             path: /var/run/docker-api
             type: DirectoryOrCreate
+        {{- if .Values.dockerApi.extraFiles }}
+        - name: files
+          secret:
+            secretName: {{ include "binderhub-service.fullname" . }}-docker-api
+            items:
+              {{- range $file_key, $file_details := .Values.dockerApi.extraFiles }}
+              - key: {{ $file_key | quote }}
+                path: {{ $file_key | quote }}
+                {{- with $file_details.mode }}
+                mode: {{ . }}
+                {{- end }}
+              {{- end }}
+        {{- end }}
       {{- with .Values.dockerApi.image.pullSecrets }}
       imagePullSecrets:
         {{- . | toYaml | nindent 8 }}

--- a/binderhub-service/templates/docker-api/secret.yaml
+++ b/binderhub-service/templates/docker-api/secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.dockerApi.extraFiles }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "binderhub-service.fullname" . }}-docker-api
+  labels:
+    {{- include "binderhub-service.labels" . | nindent 4 }}
+type: Opaque
+{{- with include "binderhub-service.extraFiles.data" .Values.dockerApi.extraFiles }}
+data:
+  {{- . | nindent 2 }}
+{{- end }}
+{{- with include "binderhub-service.extraFiles.stringData" .Values.dockerApi.extraFiles }}
+stringData:
+  {{- . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/binderhub-service/templates/service.yaml
+++ b/binderhub-service/templates/service.yaml
@@ -13,4 +13,7 @@ spec:
     - name: http
       port: {{ .Values.service.port }}
       targetPort: http
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector: {{- include "binderhub-service.selectorLabels" . | nindent 4 }}

--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -204,3 +204,29 @@ properties:
       nodeSelector: *nodeSelector
       affinity: *affinity
       tolerations: *tolerations
+      extraArgs:
+        type: array
+      extraFiles:
+        type: object
+        additionalProperties: false
+        patternProperties:
+          ".*":
+            type: object
+            additionalProperties: false
+            required: [mountPath]
+            oneOf:
+              - required: [data]
+              - required: [stringData]
+              - required: [binaryData]
+            properties:
+              mountPath:
+                type: string
+              data:
+                type: object
+                additionalProperties: true
+              stringData:
+                type: string
+              binaryData:
+                type: string
+              mode:
+                type: number

--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -19,6 +19,8 @@ required:
   - nameOverride
   - fullnameOverride
   - global
+  # Resources for the BinderHub created build pods
+  - buildPodsRegistryCredentials
   # Deployment resource
   - image
   # Other resources
@@ -45,6 +47,27 @@ properties:
   global:
     type: object
     additionalProperties: true
+
+  # Resources for the BinderHub created build pods
+  # ---------------------------------------------------------------------------
+  #
+  buildPodsDockerConfig:
+    type: object
+    additionalProperties: true
+  buildPodsRegistryCredentials:
+    type: object
+    additionalProperties: false
+    required:
+      - server
+      - username
+      - password
+    properties:
+      server:
+        type: string
+      username:
+        type: string
+      password:
+        type: string
 
   # Deployment resource
   # ---------------------------------------------------------------------------

--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -162,6 +162,8 @@ properties:
         type: string
       port:
         type: integer
+      nodePort:
+        type: integer
       annotations: *labels-and-annotations
 
   # Ingress resource

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -129,3 +129,6 @@ dockerApi:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+
+  extraArgs: []
+  extraFiles: {}

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -5,6 +5,15 @@ nameOverride: ""
 fullnameOverride: ""
 global: {}
 
+# Resources for the BinderHub created build pods
+# -----------------------------------------------------------------------------
+#
+buildPodsDockerConfig: {}
+buildPodsRegistryCredentials:
+  server: ""
+  username: ""
+  password: ""
+
 # Deployment resource
 # -----------------------------------------------------------------------------
 #
@@ -28,13 +37,18 @@ config:
   BinderHub:
     base_url: /
     port: 8585
-    use_registry: true
     require_build_only: true
   KubernetesBuildExecutor:
     # docker_host must not be updated, assumptions about it are hardcoded in
     # docker-api/daemonset.yaml
     docker_host: /var/run/docker-api/docker-api.sock
-extraConfig: {}
+extraConfig:
+  # binderhub-service creates a k8s Secret with a docker config.json file
+  # including registry credentials.
+  binderhub_service_00_build_pods_docker_config: |
+    import os
+    helm_release_name = os.environ["HELM_RELEASE_NAME"]
+    c.KubernetesBuildExecutor.push_secret = f"{helm_release_name}-build-pods-docker-config"
 
 replicas: 1
 image:

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -1,0 +1,11 @@
+# FIXME: When running tests, we will need a local container registry to test
+#        pushing images to that can be reached from the build pods.
+#
+config:
+  BinderHub:
+    use_registry: false
+    image_prefix: localhost/binderhub-service/
+buildPodsRegistryCredentials:
+  server: "localhost"
+  username: "dummy-username"
+  password: "dummy-password"

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -15,7 +15,8 @@ config:
   DockerRegistry:
     url: http://localhost:5000
   BinderHub:
-    log_level: DEBUG
+    # log_level isn't enabled to avoid overwhelming the reader with info
+    # log_level: DEBUG
     use_registry: true
     image_prefix: localhost:5000/binderhub-service/
 buildPodsRegistryCredentials:
@@ -39,5 +40,6 @@ dockerApi:
     daemon-json:
       mountPath: /etc/docker-api/daemon.json
       data:
-        debug: true
+        # debug isn't enabled to avoid overwhelming the reader with info
+        # debug: true
         insecure-registries: [localhost:5000]

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -1,12 +1,12 @@
-# FIXME: When running tests, we will need a local container registry to test
-#        pushing images to that can be reached from the build pods.
+# When running tests, we use a local container registry to test pushing images
+# to that can be reached from the build pods.
 #
 config:
   BinderHub:
     log_level: DEBUG
-    use_registry: false
-    image_prefix: localhost/binderhub-service/
+    use_registry: true
+    image_prefix: localhost:5000/binderhub-service/
 buildPodsRegistryCredentials:
-  server: "localhost"
-  username: "dummy-username"
-  password: "dummy-password"
+  server: "http://localhost:5000"
+  username: ""
+  password: ""

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -10,3 +10,7 @@ buildPodsRegistryCredentials:
   server: "http://localhost:5000"
   username: ""
   password: ""
+
+service:
+  type: NodePort
+  nodePort: 30080

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -3,6 +3,7 @@
 #
 config:
   BinderHub:
+    log_level: DEBUG
     use_registry: false
     image_prefix: localhost/binderhub-service/
 buildPodsRegistryCredentials:

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -1,16 +1,43 @@
-# When running tests, we use a local container registry to test pushing images
-# to that can be reached from the build pods.
+# NOTE: localhost:5000 will be replaced from the test job!
+#
+#       When running tests, we use a local container registry to test pushing
+#       images to that can be reached from the build pods. This local registry
+#       is run outside of k8s, so use of localhost won't work well. Due to that,
+#       all values with localhost:5000 below are set explicitly from the test
+#       job to an IP that is reachable instead.
 #
 config:
+  # DockerRegistry is a jupyterhub/binderhub class that is used to call
+  # get_image_manifest, which determines if an image needs to be built or is
+  # already available in a registry. It will not need credentials to the
+  # registry.
+  #
+  DockerRegistry:
+    url: http://localhost:5000
   BinderHub:
     log_level: DEBUG
     use_registry: true
     image_prefix: localhost:5000/binderhub-service/
 buildPodsRegistryCredentials:
-  server: "http://localhost:5000"
+  server: http://localhost:5000
   username: ""
   password: ""
 
 service:
   type: NodePort
   nodePort: 30080
+
+dockerApi:
+  # The docker-api daemonset running the docker daemon needs to be configured in
+  # a way allowing it to work against insecure HTTP (not HTTPS) registries.
+  #
+  # ref: https://docs.docker.com/registry/insecure/
+  #
+  extraArgs:
+    - --config-file=/etc/docker-api/daemon.json
+  extraFiles:
+    daemon-json:
+      mountPath: /etc/docker-api/daemon.json
+      data:
+        debug: true
+        insecure-registries: [localhost:5000]

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -58,3 +58,9 @@ dockerApi:
   securityContext:
     privileged: true
     runAsUser: 0
+  extraFiles:
+    daemon-json:
+      mountPath: /etc/docker/daemon.json
+      data:
+        debug: true
+        insecure-registries: [localhost:5000]

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -5,6 +5,16 @@ nameOverride: ""
 fullnameOverride: ""
 global: {}
 
+# Resources for the BinderHub created build pods
+# -----------------------------------------------------------------------------
+#
+buildPodsDockerConfig:
+  dummy: dummy-value
+buildPodsRegistryCredentials:
+  server: "quay.io"
+  username: "dummy-username"
+  password: "dummy-password"
+
 # Deployment resource
 # -----------------------------------------------------------------------------
 #


### PR DESCRIPTION
With binderhub-service being a Helm chart deploying to k8s, we absolutely require the ability to push the built artifact to a container registry somewhere. This enables the chart to create a k8s Secret with such credentials in a docker config format that can be mounted to the build pods via `c.KubernetesBuildExecutor.push_secret`. Users of the binderhub-service chart doesn't have to configure that manually, its instead set automatically.

## `buildPodsRegistryCredentials`

`buildPodsRegistryCredentials` should be provided with `server`, `username`, and `password` for the container registry. For a GCP based artifact-registry, this can be for example...

```yaml
config:
  BinderHub:
    use_registry: true
    image_prefix: europe-west1-docker.pkg.dev/binderhub-service-development/binderhub-service/
buildPodsRegistryCredentials:
  server: https://europe-west1-docker.pkg.dev
  # This GCP ServiceAccount is configured with:
  # - roles/artifactregistry.createOnPushWriter
  #
  username: _json_key
  password: |
    {
      "type": "service_account",
      "project_id": "binderhub-service-development",
      "private_key_id": "3ca6cb965bf9d8a23ee07220c6bfcdf70a2b4234",
      "private_key": "CENSORED",
      "client_email": "artifact-registry-push@binderhub-service-development.iam.gserviceaccount.com",
      "client_id": "101939388990083667377",
      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
      "token_uri": "https://oauth2.googleapis.com/token",
      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/artifact-registry-push%40binderhub-service-development.iam.gserviceaccount.com",
      "universe_domain": "googleapis.com"
    }
```

## `buildPodsDockerConfig`

This may not be relevant for us to use, but was added for parity with binderhub chart to some degree.

```
buildPodsDockerConfig:
  someDockerConfigRecognizableKey: and-value
```

## `dockerApi.[extraArgs|extraFiles]`

In order to setup tests with build/push, I needed to configure the docker daemon runnin on the host node to tolerate interacting with HTTP based docker registries like the one we have. Instead of doing like in jupyterhub/binderhub where a configmap is created and mounted etc in a way that is very hard to follow, I do something that is just quite hard to follow by introducing `extraFiles` taken from z2jh.

## Tests build/push

- Closes #26 by testing build and push