### PR TITLE
Trim suffix

### DIFF
--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             periodSeconds: 1
             failureThreshold: 60
             httpGet:
-              path: {{ .Values.config.BinderHub.base_url }}/versions
+              path: {{ .Values.config.BinderHub.base_url | trimSuffix "/" }}/versions
               port: http
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Otherwise I think it tries to reach out to `http://pod-ip:8585/` which fails, since we've de-registered the `/` and `/v2` endpoints.