### PR TITLE
Revert "bugfix: add docker config secret to the deployment to be mounted"

### DIFF
--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -25,9 +25,6 @@ spec:
         - name: secret
           secret:
             secretName: {{ include "binderhub-service.fullname" . }}
-        - name: docker-config-secret
-          secret:
-            secretName: {{ include "binderhub-service.fullname" . }}-build-pods-docker-config
       containers:
         - name: binderhub
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Reverts 2i2c-org/binderhub-service#48 per @consideRatio's comment:

*The secret is mounted to the build pods that are dynamically created by binderhub by configuring `KubeBuildExecutor.push_secret` somewhere in the binderhub config.*