### PR TITLE
bugfix: fix docker config secret's name used in config

### DIFF
--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -39,8 +39,8 @@ spec:
               mountPath: /etc/binderhub/mounted-secret/
               readOnly: true
           env:
-            - name: HELM_RELEASE_NAME
-              value: {{ .Release.Name }}
+            - name: HELM_DEPLOYMENT_NAME
+              value: {{ include "binderhub-service.fullname" . }}
           resources:
             {{- .Values.resources | toYaml | nindent 12 }}
           securityContext:

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -47,8 +47,8 @@ extraConfig:
   # including registry credentials.
   binderhub_service_00_build_pods_docker_config: |
     import os
-    helm_release_name = os.environ["HELM_RELEASE_NAME"]
-    c.KubernetesBuildExecutor.push_secret = f"{helm_release_name}-build-pods-docker-config"
+    helm_deployment_name = os.environ["HELM_DEPLOYMENT_NAME"]
+    c.KubernetesBuildExecutor.push_secret = f"{helm_deployment_name}-build-pods-docker-config"
 
 replicas: 1
 image:


### PR DESCRIPTION
When trying to use the latest changes in  https://github.com/2i2c-org/infrastructure/pull/2699, that deploys this into the staging namespace, I realized that `{{ .Release.Name }}` expands to `staging` and not to `staging-binderub-service` .

Hopefully this fixes it.