### PR TITLE
Set the BUILD_NAMESPACE env var to be used by KubernetesBuildExecutor

### DIFF
--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
           env:
             - name: HELM_DEPLOYMENT_NAME
               value: {{ include "binderhub-service.fullname" . }}
+            - name: BUILD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           resources:
             {{- .Values.resources | toYaml | nindent 12 }}
           securityContext:


### PR DESCRIPTION
See last point (4) of https://github.com/2i2c-org/infrastructure/pull/2699#issuecomment-1631051210