### PR TITLE
Support running multiple instances on same cluster

### DIFF
--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -41,7 +41,13 @@ spec:
           env:
             - name: HELM_DEPLOYMENT_NAME
               value: {{ include "binderhub-service.fullname" . }}
+            # Namespace build pods should be placed in
             - name: BUILD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # Namespace the binderhub pod is running in
+            - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace

--- a/binderhub-service/templates/docker-api/daemonset.yaml
+++ b/binderhub-service/templates/docker-api/daemonset.yaml
@@ -25,17 +25,17 @@ spec:
           image: {{ .Values.dockerApi.image.repository }}:{{ .Values.dockerApi.image.tag }}
           args:
             - dockerd
-            - --data-root=/var/lib/docker-api
-            - --exec-root=/var/run/docker-api
-            - --host=unix:///var/run/docker-api/docker-api.sock
+            - --data-root=/var/lib/{{ .Release.Namespace }}-{{ .Release.Name }}/docker-api
+            - --exec-root=/var/run/{{ .Release.Namespace }}-{{ .Release.Name }}/docker-api
+            - --host=unix:///var/run/{{ .Release.Namespace}}-{{ .Release.Name }}/docker-api/docker-api.sock
             {{- with .Values.dockerApi.extraArgs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: data
-              mountPath: /var/lib/docker-api
+              mountPath: /var/lib/{{ .Release.Namespace }}-{{ .Release.Name }} /docker-api
             - name: exec
-              mountPath: /var/run/docker-api
+              mountPath: /var/run/{{ .Release.Namespace }}-{{ .Release.Name }}/docker-api
             {{- range $file_key, $file_details := .Values.dockerApi.extraFiles }}
             - name: files
               mountPath: {{ $file_details.mountPath }}
@@ -48,11 +48,11 @@ spec:
       volumes:
         - name: data
           hostPath:
-            path: /var/lib/docker-api
+            path: /var/lib/{{ .Release.Namespace }}-{{ .Release.Name }}/docker-api
             type: DirectoryOrCreate
         - name: exec
           hostPath:
-            path: /var/run/docker-api
+            path: /var/run/{{ .Release.Namespace}}-{{ .Release.Name }}/docker-api
             type: DirectoryOrCreate
         {{- if .Values.dockerApi.extraFiles }}
         - name: files

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -38,17 +38,20 @@ config:
     base_url: /
     port: 8585
     enable_api_only_mode: true
-  KubernetesBuildExecutor:
-    # docker_host must not be updated, assumptions about it are hardcoded in
-    # docker-api/daemonset.yaml
-    docker_host: /var/run/docker-api/docker-api.sock
 extraConfig:
   # binderhub-service creates a k8s Secret with a docker config.json file
   # including registry credentials.
-  binderhub_service_00_build_pods_docker_config: |
+  binderhub-service-01-build-pods-docker-config: |
     import os
     helm_deployment_name = os.environ["HELM_DEPLOYMENT_NAME"]
     c.KubernetesBuildExecutor.push_secret = f"{helm_deployment_name}-build-pods-docker-config"
+
+  binderhub-service-02-set-docker-api: |
+    import os
+    helm_deployment_name = os.environ["HELM_DEPLOYMENT_NAME"]
+    namespace = os.environ["NAMESPACE"]
+    c.KubernetesBuildExecutor.docker_host = f"/var/lib/{ namespace }/{ helm_deployment_name }/docker-api/docker-api.sock"
+
 
 replicas: 1
 image:

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -50,7 +50,7 @@ extraConfig:
     import os
     helm_deployment_name = os.environ["HELM_DEPLOYMENT_NAME"]
     namespace = os.environ["NAMESPACE"]
-    c.KubernetesBuildExecutor.docker_host = f"/var/lib/{ namespace }/{ helm_deployment_name }/docker-api/docker-api.sock"
+    c.KubernetesBuildExecutor.docker_host = f"/var/lib/{ namespace }-{ helm_deployment_name }/docker-api/docker-api.sock"
 
 
 replicas: 1

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -52,7 +52,6 @@ extraConfig:
     namespace = os.environ["NAMESPACE"]
     c.KubernetesBuildExecutor.docker_host = f"/var/run/{ namespace }-{ helm_deployment_name }/docker-api/docker-api.sock"
 
-
 replicas: 1
 image:
   repository: quay.io/2i2c/binderhub-service

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -50,7 +50,7 @@ extraConfig:
     import os
     helm_deployment_name = os.environ["HELM_DEPLOYMENT_NAME"]
     namespace = os.environ["NAMESPACE"]
-    c.KubernetesBuildExecutor.docker_host = f"/var/lib/{ namespace }-{ helm_deployment_name }/docker-api/docker-api.sock"
+    c.KubernetesBuildExecutor.docker_host = f"/var/run/{ namespace }-{ helm_deployment_name }/docker-api/docker-api.sock"
 
 
 replicas: 1


### PR DESCRIPTION
Without this parameterization, all installations try to use the same hostPath paths and everything except 1 fails