### PR TITLE
Use separate variable names for push secret & helm release name

### DIFF
--- a/binderhub-service/templates/build-pods-docker-config/secret.yaml
+++ b/binderhub-service/templates/build-pods-docker-config/secret.yaml
@@ -7,6 +7,8 @@
 kind: Secret
 apiVersion: v1
 metadata:
+  # If this is changed, update the value of the  PUSH_SECRET_NAME environment
+  # variable in the binderhub deployment (in deployment.yaml)
   name: {{ include "binderhub-service.fullname" . }}-build-pods-docker-config
   labels:
     {{- include "binderhub-service.labels" . | nindent 4 }}

--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -39,8 +39,10 @@ spec:
               mountPath: /etc/binderhub/mounted-secret/
               readOnly: true
           env:
-            - name: HELM_DEPLOYMENT_NAME
-              value: {{ include "binderhub-service.fullname" . }}
+            - name: PUSH_SECRET_NAME
+              value: {{ include "binderhub-service.fullname" . }}-build-pods-docker-config
+            - name: HELM_RELEASE_NAME
+              value: {{ .Release.Name }}
             # Namespace build pods should be placed in
             - name: BUILD_NAMESPACE
               valueFrom:

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -43,14 +43,13 @@ extraConfig:
   # including registry credentials.
   binderhub-service-01-build-pods-docker-config: |
     import os
-    helm_deployment_name = os.environ["HELM_DEPLOYMENT_NAME"]
-    c.KubernetesBuildExecutor.push_secret = f"{helm_deployment_name}-build-pods-docker-config"
+    c.KubernetesBuildExecutor.push_secret = os.environ["PUSH_SECRET_NAME"]
 
   binderhub-service-02-set-docker-api: |
     import os
-    helm_deployment_name = os.environ["HELM_DEPLOYMENT_NAME"]
+    helm_release_name = os.environ["HELM_RELEASE_NAME"]
     namespace = os.environ["NAMESPACE"]
-    c.KubernetesBuildExecutor.docker_host = f"/var/run/{ namespace }-{ helm_deployment_name }/docker-api/docker-api.sock"
+    c.KubernetesBuildExecutor.docker_host = f"/var/run/{ namespace }-{ helm_release_name }/docker-api/docker-api.sock"
 
 replicas: 1
 image:


### PR DESCRIPTION
Follow-up to https://github.com/2i2c-org/binderhub-service/pull/77 (which made wrong assumptions about HELM_DEPLOYMENT_NAME).