### PR TITLE
Add extraEnv config for the deployment pod

### DIFF
--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with .Values.extraEnv }}
+            {{- tpl (. | toYaml) $ | nindent 12 }}
+            {{- end }}
           resources:
             {{- .Values.resources | toYaml | nindent 12 }}
           securityContext:

--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -85,6 +85,8 @@ properties:
     patternProperties:
       ".*":
         type: [string, "null"]
+  extraEnv:
+    type: array
 
   replicas:
     type: integer

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -51,6 +51,7 @@ extraConfig:
     namespace = os.environ["NAMESPACE"]
     c.KubernetesBuildExecutor.docker_host = f"/var/run/{ namespace }-{ helm_release_name }/docker-api/docker-api.sock"
 
+extraEnv: []
 replicas: 1
 image:
   repository: quay.io/2i2c/binderhub-service

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -21,6 +21,9 @@ buildPodsRegistryCredentials:
 image:
   repository: quay.io/2i2c/binderhub-service
   tag: "set-by-chartpress"
+extraEnv:
+  - name: HELM_RELEASE_NAME
+    value: "{{ .Release.Name }}"
 
 # RBAC resources
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This `extraEnv` allow for configuration like:

```
extraEnv:
  - name: HELM_RELEASE_NAME
    value: "{{ .Release.Name }}"
  - name: JUPYTERHUB_API_TOKEN
    valueFrom:
      secretKeyRef:
        name: '{{ include "jupyterhub.hub.fullname" . }}'
        key: hub.services.binder.apiToken
```