### PR TITLE
Drop support for k8s 1.23-1.26

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -115,7 +115,7 @@ jobs:
         include:
           - k3s-channel: latest
           - k3s-channel: stable
-          - k3s-channel: v1.24
+          - k3s-channel: v1.27
 
     steps:
       - uses: actions/checkout@v4

--- a/binderhub-service/Chart.yaml
+++ b/binderhub-service/Chart.yaml
@@ -11,7 +11,7 @@ keywords: [binderhub, binderhub-service, repo2docker, jupyterhub, jupyter]
 home: https://2i2c.org/binderhub-service
 sources: [https://github.com/2i2c-org/binderhub-service]
 icon: https://binderhub.readthedocs.io/en/latest/_static/logo.png
-kubeVersion: ">=1.23.0-0"
+kubeVersion: ">=1.27.0-0"
 maintainers:
   - name: Erik Sundell
     email: erik@sundellopensource.se


### PR DESCRIPTION
I figure we should adopt a policy like in z2jh, where we would then drop support for k8s 1.26 in June 2024 (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3321).

So, to drop now is quite reasonable. The motivation to get this done now was observing a k8s 1.24 failure in our test suite.