### PR TITLE
Update ingress config to align with zj2h config format

### DIFF
--- a/binderhub-service/templates/ingress.yaml
+++ b/binderhub-service/templates/ingress.yaml
@@ -10,32 +10,26 @@ metadata:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
-  ingressClassName: {{ . }}
-  {{- end }}
-  {{- with .Values.ingress.tls }}
-  tls:
-    {{- range . }}
-    - hosts:
-        {{- .hosts | toYaml | nindent 8 }}
-      secretName: {{ .secretName }}
-    {{- end }}
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: "{{ . }}"
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
+    {{- range $host := .Values.ingress.hosts | default (list "") }}
+    - http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- with .pathType }}
-            pathType: {{ . }}
-            {{- end }}
+          - path: {{ $.Values.config.BinderHub.base_url | trimSuffix "/" }}/{{ $.Values.ingress.pathSuffix }}
+            pathType: {{ $.Values.ingress.pathType }}
             backend:
               service:
                 name: {{ include "binderhub-service.fullname" $ }}
                 port:
-                  number: {{ $.Values.service.port }}
-          {{- end }}
+                  name: http
+      {{- if $host }}
+      host: {{ $host | quote }}
+      {{- end }}
     {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -178,7 +178,8 @@ properties:
     properties:
       enabled:
         type: boolean
-      className:
+      annotations: *labels-and-annotations
+      ingressClassName:
         type: [string, "null"]
       hosts:
         type: array
@@ -188,7 +189,6 @@ properties:
         enum: [Prefix, Exact, ImplementationSpecific]
       tls:
         type: array
-      annotations: *labels-and-annotations
 
   # DaemonSet resource - docker-api
   # ---------------------------------------------------------------------------

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -99,13 +99,11 @@ service:
 #
 ingress:
   enabled: false
-  className: ""
   annotations: {}
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
+  ingressClassName:
+  hosts: []
+  pathSuffix:
+  pathType: Prefix
   tls: []
 
 # DaemonSet resource - docker-api

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -49,7 +49,18 @@ service:
 # -----------------------------------------------------------------------------
 #
 ingress:
-  enabled: false
+  enabled: true
+  ingressClassName: mock-ingress-class-name
+  hosts:
+    - mocked1.domain.name
+    - mocked2.domain.name
+  pathSuffix: dummy-pathSuffix
+  pathType: ImplementationSpecific
+  tls:
+    - secretName: tls
+      hosts:
+        - mocked1.domain.name
+        - mocked2.domain.name
 
 # DaemonSet resource - docker-api
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This is a breaking change, but I don't think anyone has used `ingress.enabled=true` so we should be fine.