### PR TITLE
Install binderhub from git main branch instead of a fixed zipped snapshot

### DIFF
--- a/images/binderhub-service/requirements.in
+++ b/images/binderhub-service/requirements.in
@@ -2,5 +2,4 @@
 # To update requirements.txt, use the "Run workflow" button at
 # https://github.com/2i2c-org/binderhub-service/actions/workflows/watch-dependencies.yaml
 #
-binderhub @ https://github.com/jupyterhub/binderhub/archive/main.zip
---no-binary pycurl
+binderhub[pycurl] @ git+https://github.com/jupyterhub/binderhub@main

--- a/images/binderhub-service/requirements.in
+++ b/images/binderhub-service/requirements.in
@@ -2,4 +2,4 @@
 # To update requirements.txt, use the "Run workflow" button at
 # https://github.com/2i2c-org/binderhub-service/actions/workflows/watch-dependencies.yaml
 #
-binderhub[pycurl] @ https://github.com/jupyterhub/binderhub/archive/main.zip
+binderhub[pycurl] @ https://github.com/jupyterhub/binderhub/archive/main.zip --no-binary pycurl

--- a/images/binderhub-service/requirements.in
+++ b/images/binderhub-service/requirements.in
@@ -3,4 +3,4 @@
 # https://github.com/2i2c-org/binderhub-service/actions/workflows/watch-dependencies.yaml
 #
 binderhub @ https://github.com/jupyterhub/binderhub/archive/main.zip
-pycurl --no-binary
+--no-binary pycurl

--- a/images/binderhub-service/requirements.in
+++ b/images/binderhub-service/requirements.in
@@ -2,4 +2,5 @@
 # To update requirements.txt, use the "Run workflow" button at
 # https://github.com/2i2c-org/binderhub-service/actions/workflows/watch-dependencies.yaml
 #
-binderhub[pycurl] @ https://github.com/jupyterhub/binderhub/archive/main.zip --no-binary pycurl
+binderhub @ https://github.com/jupyterhub/binderhub/archive/main.zip
+pycurl --no-binary

--- a/images/binderhub-service/requirements.txt
+++ b/images/binderhub-service/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    Use the "Run workflow" button at https://github.com/2i2c-org/binderhub-service/actions/workflows/watch-dependencies.yaml
 #
---no-binary pycurl
-
 alembic==1.13.1
     # via jupyterhub
 annotated-types==0.7.0
@@ -16,8 +14,10 @@ attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
-binderhub @ https://github.com/jupyterhub/binderhub/archive/main.zip
-    # via -r requirements.in
+binderhub @ git+https://github.com/jupyterhub/binderhub@main
+    # via
+    #   -r requirements.in
+    #   binderhub
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -94,6 +94,8 @@ pyasn1-modules==0.4.0
     # via google-auth
 pycparser==2.22
     # via cffi
+pycurl==7.45.3
+    # via binderhub
 pydantic==2.7.1
     # via jupyterhub
 pydantic-core==2.18.2

--- a/images/binderhub-service/requirements.txt
+++ b/images/binderhub-service/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    Use the "Run workflow" button at https://github.com/2i2c-org/binderhub-service/actions/workflows/watch-dependencies.yaml
 #
+--no-binary pycurl
+
 alembic==1.13.1
     # via jupyterhub
 annotated-types==0.7.0

--- a/images/binderhub-service/requirements.txt
+++ b/images/binderhub-service/requirements.txt
@@ -17,9 +17,7 @@ attrs==23.2.0
     #   jsonschema
     #   referencing
 binderhub @ https://github.com/jupyterhub/binderhub/archive/main.zip
-    # via
-    #   -r requirements.in
-    #   binderhub
+    # via -r requirements.in
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -96,8 +94,6 @@ pyasn1-modules==0.4.0
     # via google-auth
 pycparser==2.22
     # via cffi
-pycurl==7.45.3
-    # via binderhub
 pydantic==2.7.1
     # via jupyterhub
 pydantic-core==2.18.2


### PR DESCRIPTION
Installing binderhub from a zip file fails with:
```
ERROR: Could not build wheels for binderhub, which is required to install pyproject.toml-based projects
```
because of 
```
ValueError: missing files: ['/tmp/pip-install-hyxm0yc_/binderhub_af833bd6869c42e39892897eaa9d8779/binderhub/static/dist/bundle.js']
```

Using git to install from the main branch seems to be fixing this. I will self-merge this to fix the tests. @consideRatio, please revert this if you disagree. 