### PR TITLE
Make sure ruamel-yaml is installed

### DIFF
--- a/images/binderhub-service/requirements.in
+++ b/images/binderhub-service/requirements.in
@@ -2,4 +2,7 @@
 # To update requirements.txt, use the "Run workflow" button at
 # https://github.com/2i2c-org/binderhub-service/actions/workflows/watch-dependencies.yaml
 #
+# needed by binderhub.config.py
+ruamel-yaml
+
 binderhub[pycurl] @ git+https://github.com/jupyterhub/binderhub@main

--- a/images/binderhub-service/requirements.txt
+++ b/images/binderhub-service/requirements.txt
@@ -144,6 +144,10 @@ rpds-py==0.18.1
     #   referencing
 rsa==4.9
     # via google-auth
+ruamel-yaml==0.18.6
+    # via -r requirements.in
+ruamel-yaml-clib==0.2.8
+    # via ruamel-yaml
 six==1.16.0
     # via
     #   kubernetes


### PR DESCRIPTION
We need ruamel-yaml pkg in the binderhub-service image because it gets used by binderhub_config.py.

Prior to this, it get installed via jupyterhub (via jupyter-telemetry), but since jupyterhub 5,  (the version that gets installed with this chart), jupyter-telemetry was replaced https://github.com/jupyterhub/jupyterhub/pull/4807, so we need be explicitly install it.