### PR TITLE
Allow nameOverride and fullnameOverride to be undefined

### DIFF
--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -16,8 +16,6 @@ type: object
 additionalProperties: false
 required:
   # General configuration
-  - nameOverride
-  - fullnameOverride
   - global
   # Resources for the BinderHub created build pods
   - buildPodsRegistryCredentials


### PR DESCRIPTION
We allow `nameOverride` and `fullnameOverride` to be null, but as part of that we should also allow them to be undefined because using helm config, its often hard to set something to null without also making it undefined.

For example `helm template binderhub-service --set fullnameOverride=null` will make it undefined and not set to null.

This is a followup to #119.