### PR TITLE
Add config `custom`

### DIFF
--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -17,6 +17,7 @@ additionalProperties: false
 required:
   # General configuration
   - global
+  - custom
   # Resources for the BinderHub created build pods
   - buildPodsRegistryCredentials
   # Deployment resource
@@ -44,6 +45,9 @@ properties:
   fullnameOverride:
     type: [string, "null"]
   global:
+    type: object
+    additionalProperties: true
+  custom:
     type: object
     additionalProperties: true
 

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -4,6 +4,7 @@
 nameOverride: ""
 fullnameOverride: ""
 global: {}
+custom: {}
 
 # Resources for the BinderHub created build pods
 # -----------------------------------------------------------------------------

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -4,6 +4,7 @@
 nameOverride: ""
 fullnameOverride: ""
 global: {}
+custom: {}
 
 # Resources for the BinderHub created build pods
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
- fixes #134 

The implementation is like z2jh, which is [documented there](https://z2jh.jupyter.org/en/stable/resources/reference.html#custom):

>Additional values to pass to the Hub. JupyterHub will not itself look at these, but you can read values in your own custom config via hub.extraConfig. For example:
>
>```yaml
>custom:
>  myHost: "https://example.horse"
>hub:
>  extraConfig:
>    myConfig.py: |
>      c.MyAuthenticator.host = get_config("custom.myHost")
>```

This can be used to help toggle larger code sections in extraConfig for example.
