### PR TITLE
Add a couple features to work towards feature parity with old binderhub chart

### DIFF
--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         - name: secret
           secret:
             secretName: {{ include "binderhub-service.binderhub.fullname" . }}
+        {{- with .Values.extraVolumes }}
+        {{- tpl (. | toYaml) $ | nindent 8 }}
+        {{- end }}
       containers:
         - name: binderhub
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -38,6 +41,9 @@ spec:
             - name: secret
               mountPath: /etc/binderhub/mounted-secret/
               readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{- tpl (. | toYaml) $ | nindent 12 }}
+            {{- end }}
           env:
             - name: PUSH_SECRET_NAME
               value: {{ include "binderhub-service.build-pods-docker-config.fullname" . }}

--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -96,6 +96,10 @@ properties:
         type: string
   extraEnv:
     type: array
+  extraVolumes:
+    type: array
+  extraVolumeMounts:
+    type: array
 
   replicas:
     type: integer

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -38,7 +38,6 @@ config:
   BinderHub:
     base_url: /
     port: 8585
-    enable_api_only_mode: true
 extraConfig:
   # binderhub-service creates a k8s Secret with a docker config.json file
   # including registry credentials.


### PR DESCRIPTION
- allow setting `extraVolumes` and `extraVolumeMounts` on the binder pod
- Don't override `enable_api_only_mode` - use whatever the default in binderhub is

The eventual goal here is to replace https://github.com/jupyterhub/binderhub/tree/main/helm-chart with this project - see https://github.com/jupyterhub/binderhub/pull/1862.