### PR TITLE
fix: rework labels used for selecting

### DIFF
--- a/binderhub-service/templates/_helpers-labels.tpl
+++ b/binderhub-service/templates/_helpers-labels.tpl
@@ -3,7 +3,7 @@
 */}}
 {{- define "binderhub-service.labels" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{ include "binderhub-service.selectorLabels" . }}
+{{ include "binderhub-service.appLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -11,9 +11,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{- /*
-  Selector labels
+  App labels
 */}}
-{{- define "binderhub-service.selectorLabels" -}}
+{{- define "binderhub-service.appLabels" -}}
 app.kubernetes.io/name: {{ .Values.nameOverride | default .Chart.Name | trunc 63 | trimSuffix "-" }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{- include "binderhub-service.selectorLabels" . | nindent 6 }}
+      {{- include "binderhub-service.appLabels" . | nindent 6 }}
       app.kubernetes.io/component: binderhub
   template:
     metadata:
@@ -18,7 +18,7 @@ spec:
         {{- . | toYaml | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "binderhub-service.selectorLabels" . | nindent 8 }}
+        {{- include "binderhub-service.appLabels" . | nindent 8 }}
         app.kubernetes.io/component: binderhub
     spec:
       volumes:

--- a/binderhub-service/templates/docker-api-network-policy.yaml
+++ b/binderhub-service/templates/docker-api-network-policy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      {{- include "binderhub-service.selectorLabels" . | nindent 6 }}
+      {{- include "binderhub-service.appLabels" . | nindent 6 }}
       app.kubernetes.io/component: docker-api
   policyTypes:
     - Egress

--- a/binderhub-service/templates/docker-api/daemonset.yaml
+++ b/binderhub-service/templates/docker-api/daemonset.yaml
@@ -8,12 +8,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "binderhub-service.selectorLabels" . | nindent 6 }}
+      {{- include "binderhub-service.appLabels" . | nindent 6 }}
       app.kubernetes.io/component: docker-api
   template:
     metadata:
       labels:
-        {{- include "binderhub-service.selectorLabels" . | nindent 8 }}
+        {{- include "binderhub-service.appLabels" . | nindent 8 }}
         app.kubernetes.io/component: docker-api
       {{- with .Values.podAnnotations }}
       annotations:

--- a/binderhub-service/templates/service.yaml
+++ b/binderhub-service/templates/service.yaml
@@ -16,4 +16,6 @@ spec:
       {{- with .Values.service.nodePort }}
       nodePort: {{ . }}
       {{- end }}
-  selector: {{- include "binderhub-service.selectorLabels" . | nindent 4 }}
+  selector: 
+    {{- include "binderhub-service.appLabels" . | nindent 4 }}
+    app.kubernetes.io/component: binderhub

--- a/tools/templates/yamllint-config.yaml
+++ b/tools/templates/yamllint-config.yaml
@@ -4,5 +4,6 @@ rules:
     indent-sequences: whatever # Default true (*)
   line-length: disable # Default: { max: 80, ... }
 
+
 # (*) toYaml's emitted sequences/lists will have no indentation and we have no
 # control over it, so we compromise by setting "whatever".


### PR DESCRIPTION
After switching to the nginx-ingress, 2i2c noticed 502 errors as nginx could not reach the binderhub-service. This is due to the way that nginx-ingress uses the service selector to generate EndPointSlices from the matching service pods. For the present labeling scheme, both the `binderhub` and the `docker-api` pods match these labels, ultimately leading to errors.

I haven't looked at the `git blame`, but I suspect that the purpose of `selectorLabels` has changed over time, and `appLabels` may be more appropriate. As long as the service is selecting on a different set of labels to those held by the docker API pod, all is well!