### PR TITLE
Allow binder pod to talk to hub pod

### DIFF
--- a/binderhub-service/templates/deployment.yaml
+++ b/binderhub-service/templates/deployment.yaml
@@ -20,6 +20,11 @@ spec:
       labels:
         {{- include "binderhub-service.appLabels" . | nindent 8 }}
         app.kubernetes.io/component: binderhub
+        # Allow the binder pod to talk to the hub pod for authentication
+        hub.jupyter.org/network-access-hub: "true"
+        {{- with .Values.podLabels }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
     spec:
       volumes:
         - name: secret

--- a/binderhub-service/values.schema.yaml
+++ b/binderhub-service/values.schema.yaml
@@ -140,6 +140,7 @@ properties:
     patternProperties:
       ".*":
         type: string
+  podLabels: *labels-and-annotations
   nodeSelector: &nodeSelector
     type: object
     additionalProperties: true

--- a/binderhub-service/values.yaml
+++ b/binderhub-service/values.yaml
@@ -74,6 +74,7 @@ securityContext:
 
 podSecurityContext: {}
 podAnnotations: {}
+podLabels: {}
 nodeSelector: {}
 affinity: {}
 tolerations: []


### PR DESCRIPTION
- Also allow setting additional labels on binder pod

Ref https://github.com/2i2c-org/infrastructure/issues/8453